### PR TITLE
feat: 회원가입·로그인 API 연동 및 accessToken 로컬 스토리지 저장

### DIFF
--- a/src/app/(main)/login/LoginForm.jsx
+++ b/src/app/(main)/login/LoginForm.jsx
@@ -1,17 +1,80 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation'; // ✅ Next.js용 라우터
 import './AuthForm.css';
+import axios from 'axios';
+
+function generateUUID() {
+  // 간단한 UUID 생성 함수 (RFC4122 버전4 형식)
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
 
 export default function LoginForm() {
   const [id, setId] = useState('');
   const [pw, setPw] = useState('');
   const router = useRouter(); // ✅ 페이지 이동용
+  const [deviceId, setDeviceId] = useState('');
 
-  const handleSubmit = e => {
+  useEffect(() => {
+    // 기기에 저장된 deviceId가 있으면 불러오고, 없으면 새로 생성해서 저장
+    let storedDeviceId = localStorage.getItem('deviceId');
+    if (!storedDeviceId) {
+      storedDeviceId = generateUUID();
+      localStorage.setItem('deviceId', storedDeviceId);
+    }
+    setDeviceId(storedDeviceId);
+  }, []);
+
+  const handleSubmit = async e => {
     e.preventDefault();
-    alert(`ID: ${id}\nPW: ${pw}`);
+    console.log('[✅ handleSubmit 호출됨]');
+
+    try {
+      const url = `${process.env.NEXT_PUBLIC_API_USER}/user-management/auth/login`;
+      console.log('[로그인 요청 경로]', url); // 🔍 실제 요청 URL 확인
+
+      const response = await axios.post(url, {
+        emailId: id,
+        password: pw,
+        deviceId, // 자동 생성된 deviceId 사용
+      });
+
+      console.log('서버 응답:', response.data);
+
+      // 로그인 성공 시 처리
+      // 예) 토큰 저장, 페이지 이동 등
+      // 서버에서 토큰 받는다고 가정
+      const { accessToken } = response.data.data;
+
+      if (accessToken) {
+        // 예: 로컬 스토리지에 저장
+        localStorage.setItem('accessToken', accessToken);
+        alert('로그인 성공!');
+        router.push('/'); // 메인 페이지 등 이동
+      }
+    } catch (error) {
+      console.error('로그인 실패:', error);
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        if (status === 401) {
+          alert('아이디 또는 비밀번호가 올바르지 않습니다.');
+        } else {
+          alert(
+            '로그인 실패! ' +
+              (typeof error.response?.data === 'string'
+                ? error.response.data
+                : error.response?.data?.message || '서버 오류'),
+          );
+        }
+      } else {
+        alert('로그인 실패! 알 수 없는 오류가 발생했습니다.');
+      }
+    }
   };
 
   return (

--- a/src/app/(main)/register/RegisterForm.jsx
+++ b/src/app/(main)/register/RegisterForm.jsx
@@ -1,27 +1,55 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation'; // ✅ Next.js용 라우터
+import axios from 'axios';
 
 export default function RegisterForm({ onSwitch }) {
   const [id, setId] = useState('');
   const [pw, setPw] = useState('');
   const [pw2, setPw2] = useState('');
-  const [phone, setPhone] = useState('');
   const router = useRouter();
 
-  const handleSubmit = e => {
+  const handleRegister = async e => {
     e.preventDefault();
+    console.log('[✅ handleRegister 호출됨]');
     if (pw !== pw2) {
       alert('비밀번호가 일치하지 않습니다.');
       return;
     }
-    // 회원가입 처리 로직 (API 연동 등)
-    alert(`ID: ${id}\nPW: ${pw}\nPhone: ${phone}`);
+
+    try {
+      const url = `${process.env.NEXT_PUBLIC_API_USER}/user-management/users/register`;
+      console.log('[회원가입 요청 경로]', url); // 🔍 실제 요청 URL 확인
+      const response = await axios.post(url, {
+        emailId: id,
+        password: pw,
+      });
+
+      alert('회원가입 성공!');
+      console.log('서버 응답:', response.data);
+      router.push('/login'); // 성공 시 로그인 페이지로 이동
+    } catch (error) {
+      console.error('회원가입 실패:', error);
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        if (status === 409) {
+          alert('이미 존재하는 이메일입니다.');
+        } else {
+          const msg =
+            typeof error.response?.data === 'string'
+              ? error.response.data
+              : error.response?.data?.message || '서버 오류';
+          alert('회원가입 실패! ' + msg);
+        }
+      } else {
+        alert('회원가입 실패! 알 수 없는 오류가 발생했습니다.');
+      }
+    }
   };
 
   return (
     <div className="auth-container">
-      <h2 className="auth-title">NAVER</h2>
-      <form className="auth-form" onSubmit={handleSubmit}>
+      <h2 className="auth-title">PLAYBLOG</h2>
+      <form className="auth-form" onSubmit={handleRegister}>
         <input type="text" placeholder="아이디" value={id} onChange={e => setId(e.target.value)} />
         <input
           type="password"


### PR DESCRIPTION
- 회원가입 및 로그인 기능 API 연동 완료
- 로그인 성공 시 accessToken과 refreshToken을 localStorage에 저장
- 이후 요청에서 localStorage.getItem('accessToken')으로 토큰 접근 가능